### PR TITLE
Fix result display on form submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,9 @@
           </select>
         </fieldset>
       </form>
+      <div id="result"></div>
       <script>
+      const result = document.getElementById('result');
       const selects = custom.querySelectorAll('select');
       for (const select of selects) {
           const div = document.createElement('div');
@@ -331,7 +333,7 @@
       document.forms[0].onsubmit = function(e) {
           const data = new FormData(this);
           e.preventDefault();
-          submit.innerText = JSON.stringify([...data.entries()]);
+          result.innerText = JSON.stringify([...data.entries()]);
       }
       </script>
   </body>


### PR DESCRIPTION
## Summary
- display form data results in a new `div`
- reference the result element in the script

## Testing
- `node - <<'NODE'
const fs = require('fs');
const data = fs.readFileSync('index.html', 'utf8');
const script = data.match(/<script>([\s\S]*?)<\/script>/)[1];
try { new Function(script); console.log('No syntax errors'); } catch(e){ console.error(e.message); }
NODE`

------
https://chatgpt.com/codex/tasks/task_e_686a5d8a31e883279dc958be89eef24a