### PR TITLE
Add profile and deposit features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ This repository contains a small prototype for a group subscription matching ser
 - Listing parties and joining an existing party
 
 The server stores data in memory and is intended for demonstration purposes only.
+Additional sample features include:
+
+- Updating a user's profile
+- Simple wallet deposit handling
+- Tracking party membership history
 
 ## Requirements
 

--- a/src/app.js
+++ b/src/app.js
@@ -2,10 +2,12 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import authRouter from './routes/auth.js';
 import partyRouter from './routes/party.js';
+import userRouter from './routes/user.js';
 
 const app = express();
 app.use(bodyParser.json());
 app.use(authRouter);
 app.use(partyRouter);
+app.use(userRouter);
 
 export default app;

--- a/src/data/store.js
+++ b/src/data/store.js
@@ -1,6 +1,9 @@
 export const store = {
+  // Users are objects {id, email, password, profile, balance, history}
   users: [],
+  // token -> userId
   sessions: {},
+  // Parties are objects {id, name, deposit, serviceName, startDate, owner, members, deposits}
   parties: [],
   nextUserId: 1,
   nextPartyId: 1

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -4,14 +4,21 @@ import { store } from '../data/store.js';
 const router = Router();
 
 router.post('/register', (req, res) => {
-  const { email, password } = req.body;
+  const { email, password, nickname, image } = req.body;
   if (!email || !password) {
     return res.status(400).json({ error: 'Missing fields' });
   }
   if (store.users.find(u => u.email === email)) {
     return res.status(400).json({ error: 'Email exists' });
   }
-  const user = { id: store.nextUserId++, email, password };
+  const user = {
+    id: store.nextUserId++,
+    email,
+    password,
+    profile: { nickname: nickname || '', image: image || '' },
+    balance: 0,
+    history: []
+  };
   store.users.push(user);
   res.json({ id: user.id, email: user.email });
 });

--- a/src/routes/party.js
+++ b/src/routes/party.js
@@ -16,9 +16,21 @@ router.post('/party', auth, (req, res) => {
     serviceName,
     startDate: startDate || new Date().toISOString(),
     owner: req.userId,
-    members: [req.userId]
+    members: [req.userId],
+    deposits: {}
   };
   store.parties.push(party);
+  const owner = store.users.find(u => u.id === req.userId);
+  if (owner) {
+    owner.history.push(party.id);
+    if (party.deposit > 0) {
+      if (owner.balance < party.deposit) {
+        return res.status(400).json({ error: 'Insufficient balance' });
+      }
+      owner.balance -= party.deposit;
+      party.deposits[owner.id] = party.deposit;
+    }
+  }
   res.json(party);
 });
 
@@ -31,8 +43,18 @@ router.post('/party/:partyId/join', auth, (req, res) => {
   if (!party) {
     return res.status(404).json({ error: 'Party not found' });
   }
+  const user = store.users.find(u => u.id === req.userId);
+  if (!user) return res.status(404).json({ error: 'User not found' });
   if (!party.members.includes(req.userId)) {
+    if (party.deposit > 0) {
+      if (user.balance < party.deposit) {
+        return res.status(400).json({ error: 'Insufficient balance' });
+      }
+      user.balance -= party.deposit;
+      party.deposits[req.userId] = party.deposit;
+    }
     party.members.push(req.userId);
+    user.history.push(party.id);
   }
   res.json({ success: true });
 });

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,0 +1,40 @@
+import { Router } from 'express';
+import { store } from '../data/store.js';
+import { auth } from '../auth.js';
+
+const router = Router();
+
+router.get('/me', auth, (req, res) => {
+  const user = store.users.find(u => u.id === req.userId);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+  res.json({
+    id: user.id,
+    email: user.email,
+    profile: user.profile,
+    balance: user.balance,
+    history: user.history
+  });
+});
+
+router.post('/profile', auth, (req, res) => {
+  const { nickname, image } = req.body;
+  const user = store.users.find(u => u.id === req.userId);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+  if (nickname !== undefined) user.profile.nickname = nickname;
+  if (image !== undefined) user.profile.image = image;
+  res.json({ profile: user.profile });
+});
+
+router.post('/deposit', auth, (req, res) => {
+  const { amount } = req.body;
+  const user = store.users.find(u => u.id === req.userId);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+  const parsed = parseFloat(amount);
+  if (isNaN(parsed) || parsed <= 0) {
+    return res.status(400).json({ error: 'Invalid amount' });
+  }
+  user.balance += parsed;
+  res.json({ balance: user.balance });
+});
+
+export default router;

--- a/test.js
+++ b/test.js
@@ -38,12 +38,19 @@ function request(method, path, data, token) {
     assert.strictEqual(res.status, 200);
     const token = res.body.token;
 
+    res = await request('POST', '/deposit', { amount: 20 }, token);
+    assert.strictEqual(res.status, 200);
+
     res = await request('POST', '/party', { name: 'Test Party', serviceName: 'Netflix', deposit: 10 }, token);
     assert.strictEqual(res.status, 200);
     const partyId = res.body.id;
 
     res = await request('POST', `/party/${partyId}/join`, null, token);
     assert.strictEqual(res.status, 200);
+
+    res = await request('GET', '/me', null, token);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.balance, 10);
 
     res = await request('GET', '/parties');
     assert.strictEqual(res.status, 200);


### PR DESCRIPTION
## Summary
- add user profile and wallet deposit API routes
- deduct party deposits from wallet balance
- keep per-user history of joined parties
- test the new features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687261c4cd90832781106f9097e534bf